### PR TITLE
Caching Tweak and Documentation

### DIFF
--- a/addons/card-framework/card.gd
+++ b/addons/card-framework/card.gd
@@ -7,12 +7,16 @@ static var hovering_card_count: int = 0
 
 ## The name of the card.
 @export var card_name: String
+
 ## The size of the card.
 @export var card_size: Vector2 = Vector2(150, 210)
+
 ## The texture for the front face of the card.
 @export var front_image: Texture2D
+
 ## The texture for the back face of the card.
 @export var back_image: Texture2D
+
 ## Whether the front face of the card is shown.
 ## If true, the front face is visible; otherwise, the back face is visible.
 @export var show_front: bool = true:

--- a/addons/card-framework/card_container.gd
+++ b/addons/card-framework/card_container.gd
@@ -6,15 +6,18 @@ static var next_id = 0
 
 
 @export_group("drop_zone")
+
 ## Enables or disables the drop zone functionality.
 @export var enable_drop_zone := true
 @export_subgroup("Sensor")
+
 ## The size of the sensor. If not set, it will follow the size of the card.
 @export var sensor_size: Vector2
-## The position of the sensor.
+
 @export var sensor_position: Vector2
-## The texture used for the sensor.
+
 @export var sensor_texture: Texture
+
 ## Determines whether the sensor is visible or not.
 ## Since the sensor can move following the status, please use it for debugging.
 @export var sensor_visibility := false
@@ -27,6 +30,8 @@ var _held_cards := []
 var _holding_cards := []
 var cards_node: Control
 var card_manager: CardManager
+
+## Debug Mode shows outlines for card drop zones.
 var debug_mode := false
 
 
@@ -72,7 +77,7 @@ func _exit_tree() -> void:
 	if card_manager != null:
 		card_manager._delete_card_container(unique_id)
 
-
+## Adds a card to this container
 func add_card(card: Card, index: int = -1) -> void:
 	if index == -1:
 		_assign_card_to_container(card)
@@ -80,7 +85,8 @@ func add_card(card: Card, index: int = -1) -> void:
 		_insert_card_to_container(card, index)
 	_move_object(card, cards_node, index)
 
-
+## Finds and removes a card from this container.[br]
+## Returns [code]true[/code] if the operation is successful, [code]false[/code] if it isn't.
 func remove_card(card: Card) -> bool:
 	var index = _held_cards.find(card)
 	if index != -1:
@@ -90,11 +96,11 @@ func remove_card(card: Card) -> bool:
 	update_card_ui()
 	return true
 
-
+## Returns [code]true[/code] if this container contains [param card], [code]false[/code] if it doesn't.
 func has_card(card: Card) -> bool:
 	return _held_cards.has(card)
 
-
+## Removes all cards from this container.
 func clear_cards():
 	for card in _held_cards:
 		_remove_object(card)
@@ -127,7 +133,7 @@ func get_partition_index() -> int:
 		return horizontal_index
 	return -1
 
-
+## Shuffle the order of cards in this container.
 func shuffle() -> void:
 	_fisher_yates_shuffle(_held_cards)
 	for i in range(_held_cards.size()):
@@ -203,7 +209,7 @@ func _move_to_card_container(_card: Card, index: int = -1) -> void:
 		_card.card_container.remove_card(_card)
 	add_card(_card, index)
 
-
+## [url]https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle[/url]
 func _fisher_yates_shuffle(array: Array) -> void:
 	for i in range(array.size() - 1, 0, -1):
 		var j = randi() % (i + 1)

--- a/addons/card-framework/card_factory.gd
+++ b/addons/card-framework/card_factory.gd
@@ -1,16 +1,22 @@
 @tool
 class_name CardFactory
 extends Node
+## Base Class for loading and making Card instances.
 
-var preloaded_cards = {}
+
+## Cache for card data. [method preload_card_data] should populate this at some
+## point, and [method create_card] ideally would check for this.
+var preloaded_cards : Dictionary = {}
+
 var card_size: Vector2
 
-# @param target: The CardContainer where the card will be added.
-# @return: The created Card instance.
+## [param target]: The CardContainer where the card will be added.[br]
+## Returns the created Card instance.
 func create_card(card_name: String, target: CardContainer) -> Card:
 	return null
-	
-# Preloads card data into the `preloaded_cards` dictionary.
-# This function should be called to initialize card data before creating cards.
+
+
+## Preloads card data into the [member preloaded_cards] dictionary.
+## This function should be called to initialize card data before creating cards.
 func preload_card_data() -> void:
 	pass

--- a/addons/card-framework/card_manager.gd
+++ b/addons/card-framework/card_manager.gd
@@ -6,11 +6,13 @@ extends Control
 const CARD_ACCEPT_TYPE = "card"
 
 
-## size of the card
+## Size of the card in viewport units (pixels)
 @export var card_size := Vector2(150, 210)
-## card factory scene
+
+## PackedScene responsible for making Card instances in the game
 @export var card_factory_scene: PackedScene
-## debug mode
+
+## Debug Mode shows outlines for card drop zones.
 @export var debug_mode := false
 
 

--- a/addons/card-framework/draggable_object.gd
+++ b/addons/card-framework/draggable_object.gd
@@ -7,8 +7,10 @@ const Z_INDEX_OFFSET_WHEN_HOLDING = 1000
 
 ## The speed at which the objects moves.
 @export var moving_speed: int = 2000
+
 ## Whether the object can be interacted with.
 @export var can_be_interacted_with: bool = true
+
 ## The distance the object hovers when interacted with.
 @export var hover_distance: int = 10
 

--- a/addons/card-framework/drop_zone.gd
+++ b/addons/card-framework/drop_zone.gd
@@ -14,11 +14,11 @@ var sensor_position: Vector2:
 	set(value):
 		sensor.position = value
 		sensor_outline.position = value
-## @deprecated: Since it was designed to debug the sensor, please use sensor_outline_visible instead.
+## @deprecated: Since it was designed to debug the sensor, please use [member sensor_outline_visible] instead.
 var sensor_texture : Texture:
 	set(value):
 		sensor.texture = value
-## @deprecated: Since it was designed to debug the sensor, please use sensor_outline_visible instead.
+## @deprecated: Since it was designed to debug the sensor, please use [member sensor_outline_visible] instead.
 var sensor_visible := true:
 	set(value):
 		sensor.visible = value

--- a/addons/card-framework/hand.gd
+++ b/addons/card-framework/hand.gd
@@ -2,26 +2,34 @@ class_name Hand
 extends CardContainer
 
 @export_group("hand_meta_info")
-## maximum number of cards that can be held.
+
+## Maximum number of cards that can be held.
 @export var max_hand_size := 10
-## maximum spread of the hand.
+
+## Maximum spread of the hand.
 @export var max_hand_spread := 700
-## whether the card is face up.
+
+## Whether the cards in hand are shown face up or face down.
 @export var card_face_up := true
-## distance the card hovers when interacted with.
+
+## Distance the card hovers when interacted with.
 @export var card_hover_distance := 30
 
 @export_group("hand_shape")
-## rotation curve of the hand.
+
+## Rotation curve of the hand.
 ## This works best as a 2-point linear rise from -X to +X.
 @export var hand_rotation_curve : Curve
-## vertical curve of the hand.
+
+## Vertical curve of the hand.
 ## This works best as a 3-point ease in/out from 0 to X to 0
 @export var hand_vertical_curve : Curve
 
 @export_group("drop_zone")
-## Determines whether the drop zone size follows the hand size. (requires enable drop zone true)
+
+## Determines whether the drop zone size follows the hand size. (Requires enable drop zone true)
 @export var align_drop_zone_size_with_current_hand_size := true
+
 ## If true, only swap the positions of two cards when reordering (a <-> b), otherwise shift the range (default behavior).
 @export var swap_only_on_reorder := false
 

--- a/addons/card-framework/json_card_factory.gd
+++ b/addons/card-framework/json_card_factory.gd
@@ -1,13 +1,25 @@
 @tool
 class_name JsonCardFactory
 extends CardFactory
+## Loads cards from JSON files in a specified directory and makes Card instances.
+##
+## This is an example card factory importing from JSON files
+## and makes cards sharing the same backside texture.
+## Card data is loaded from [member card_info_dir] and
+## their frontside images from [member card_asset_dir].
+##
+## You may extend it further or make a copy to load from another file type.
+
 
 ## a base card scene to instantiate.
 @export var default_card_scene: PackedScene
+
 ## card image asset directory
 @export var card_asset_dir: String
+
 ## card information json directory
 @export var card_info_dir: String
+
 ## common back face image of cards
 @export var back_image: Texture2D
 
@@ -23,7 +35,8 @@ func _ready() -> void:
 		default_card_scene = null
 	temp_instance.queue_free()
 
-
+## [param target]: The CardContainer where the card will be added.[br]
+## Returns the created Card instance.[br]
 func create_card(card_name: String, target: CardContainer) -> Card:
 	# check card info is cached
 	if preloaded_cards.has(card_name):
@@ -45,6 +58,8 @@ func create_card(card_name: String, target: CardContainer) -> Card:
 			push_error("Card image not found: %s" % front_image_path)
 			return null
 
+		# TODO: add to cache as we know the card isn't in there, 
+		# maybe make a function like preload_card_data but for an individual card
 		return _create_card_node(card_info.name, front_image, target, card_info)
 
 

--- a/addons/card-framework/pile.gd
+++ b/addons/card-framework/pile.gd
@@ -15,20 +15,27 @@ const PILE_Z_INDEX := 3000
 
 ## The distance between each card in the pile.
 @export var stack_display_gap := 8
+
 ## The maximum number of cards to display in the pile.
 @export var max_stack_display := 6
+
 ## Determines whether the cards in the pile are face up.
 @export var card_face_up := true
+
 ## The direction in which the cards are stacked.
 @export var layout := PileDirection.UP
+
 ## Determines whether any card in the pile can be moved.
 @export var allow_card_movement: bool = true
-## Restricts movement to only the top card of the pile. (requires allow_card_movement to be true)
+
+## Restricts movement to only the top card of the pile. (requires [member allow_card_movement] to be true)
 @export var restrict_to_top_card: bool = true
-## Determines whether the drop zone follows the top card. (requires allow_card_movement to be true)
+
+## Determines whether the drop zone follows the top card. (requires [member allow_card_movement] to be true)
 @export var align_drop_zone_with_top_card := true
 
-
+## Get a list of the top [param n] cards in this pile.
+## The top-most cards on a pile are the bottom-most on the scene tree.
 func get_top_cards(n: int) -> Array:
 	var arr_size = _held_cards.size()
 	if n > arr_size:


### PR DESCRIPTION
JsonCardFactory now caches cards it loaded manually if they weren't in the cache before.
Also made a method ``load_card_full_data()`` to remove code repetition from both preloading and creating without cache, so if someone else wants a new data structure they don't need to change two places.

Also tweaked some of the comments to show up on internal docs and on hover. Documentation is not complete though, as I'm also learning what some of these do, just made existing comments show up, and added extra ones on the Factory nodes.
Commit messages have some extra comments. Open to feedback.