### PR TITLE
fix: Fallback value for can be interacted with

### DIFF
--- a/addons/card-framework/pile.gd
+++ b/addons/card-framework/pile.gd
@@ -115,7 +115,8 @@ func _update_target_positions() -> void:
 				card.can_be_interacted_with = true
 			else:
 				card.can_be_interacted_with = false
-
+		else:
+			card.can_be_interacted_with = true
 
 ## Calculates the visual offset for a card at the given index in the stack.
 ## Respects max_stack_display limit to prevent excessive visual spreading.


### PR DESCRIPTION
This issue can be raise if a card was set to can_be_interacted_with to false and move via code to another pile. The state should be assigned properly base on the current pile logic