### PR TITLE
Fix card layout position when Pile is a child node of a Container

### DIFF
--- a/addons/card-framework/pile.gd
+++ b/addons/card-framework/pile.gd
@@ -101,7 +101,7 @@ func _update_target_positions() -> void:
 	for i in range(_held_cards.size()):
 		var card = _held_cards[i]
 		var offset = _calculate_offset(i)
-		var target_pos = position + offset
+		var target_pos = global_position + offset
 		
 		# Set card appearance and position
 		card.show_front = card_face_up


### PR DESCRIPTION
The draggable_object.gd move() function accepts a global position. Pile was previously passing its target_pos as an offset from its relative `position` rather than an offset from its `global_position`.

This worked fine so long as the Pile instance was not the child of a Container, since its `position` and `global_position` would be identical. However, placing a Pile within something like VBoxContainer would cause move() to be called offset from (0, 0), causing cards be positioned in the top corner.

The drop_zone logic was already correct; it positions as expected within the Container.